### PR TITLE
ci: ♻️dependabot uses conventional commit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    commit-message:
+      prefix: "ci"
     groups:
       ci:
         patterns:


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- Dependabot の更新について、コミットメッセージのプレフィックス "ci" を .github/dependabot.yml に追加しました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Add commit-message prefix "ci" to .github/dependabot.yml for Dependabot updates

</details>