### PR TITLE
ci: disable persist-credentials on checkout actions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -25,6 +25,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:

--- a/.github/workflows/pull-request-title-lint.yml
+++ b/.github/workflows/pull-request-title-lint.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: 🐣 Install bun
         uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76
         with:
@@ -33,7 +34,6 @@ jobs:
           ignores: [(message: string) => message.includes("Signed-off-by: dependabot[bot]")] }' > commitlint.config.ts
 
       - name: 👀 Validate PR title with commitlint
-        if: github.event_name == 'pull_request'
         id: commitlint
         env:
           TITLE: ${{ github.event.pull_request.title }}


### PR DESCRIPTION
## Sourcery による概要

チェックアウトアクションでの認証情報の永続化を無効にし、pull_request限定の条件を削除することでcommitlintの検証が常に実行されるようにします。

改善点:
- CIワークフローの `actions/checkout` ステップで `persist-credentials` を無効化
- commitlint検証ステップの `pull_request` イベントガードを削除

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Disable persisting credentials in checkout actions and ensure commitlint validation always runs by removing its pull_request-only condition

Enhancements:
- Disable persist-credentials in actions/checkout steps of CI workflows
- Remove the pull_request event guard on the commitlint validation step

</details>