### PR TITLE
ci: prevent script injection in comment workflow

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -23,50 +23,41 @@ jobs:
         with:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
-      - name: ⚙️ Setup Environment
-        run: |
-          echo "PR_NUMBER=$(cat pr_number/pr_number.txt | tr -cd '0-9')" >> $GITHUB_ENV
-          echo "TITLE=$(cat title/title.txt | tr -d '\n')" >> $GITHUB_ENV
-          UUID=$(uuidgen)
-          {
-            echo "COMMENT<<EOF_$UUID"
-            cat comment/comment.txt
-            echo "EOF_$UUID"
-          } >> "$GITHUB_ENV"
 
       - name: 💬 Add a comment
         uses: actions/github-script@v9
         env:
           CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
         with:
           script: |
+            const fs = require('fs');
+
+            const prNumber = fs.readFileSync('pr_number/pr_number.txt', 'utf8').replace(/[^0-9]/g, '');
+            const comment = fs.readFileSync('comment/comment.txt', 'utf8');
+
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: process.env.PR_NUMBER,
+              issue_number: prNumber,
             })
-            const oldComment = comments.find(comment => {
-              return comment.user.type === 'Bot' && comment.body.includes(process.env.TITLE)
+            const oldComment = comments.find(c => {
+              return c.user.type === 'Bot' && c.body.includes(process.env.WORKFLOW_NAME)
             })
+            const shouldComment = oldComment || process.env.CONCLUSION === 'failure'
+            if (!shouldComment) return
+
             if (oldComment) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: oldComment.id,
               })
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: process.env.PR_NUMBER,
-                body: process.env.COMMENT
-              })
-              return
             }
-            if (process.env.CONCLUSION === 'failure') {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: process.env.PR_NUMBER,
-                body: process.env.COMMENT
-              })
-            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            })


### PR DESCRIPTION
Read PR number and comment body via fs.readFileSync inside actions/github-script
instead of piping artifact contents through GITHUB_ENV in shell. The previous
'Setup Environment' step was flagged by GitHub security review for potential
injection of attacker-controlled data (PR title) from the workflow_run trigger.

Match old comments by github.event.workflow_run.name (workflow YAML, trusted)
instead of the user-supplied PR title from the artifact.

## Summary by Sourcery

スクリプトインジェクションに対して GitHub Actions のコメント用ワークフローを強化しつつ、プルリクエストへのコメント投稿方法を簡素化します。

CI:
- `GITHUB_ENV` へのシェルコマンドによるエクスポートではなく、`actions/github-script` の中でワークフローアーティファクトから直接プルリクエスト番号とコメント本文を読み取るように変更。
- アーティファクト由来のユーザー入力である PR タイトルではなく、信頼できる `workflow_run.name` を使って既存のボットコメントを検出・置換し、コメントを作成する条件分岐ロジックを簡素化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden the GitHub Actions comment workflow against script injection while simplifying how comments are posted to pull requests.

CI:
- Read the pull request number and comment body from workflow artifacts directly within actions/github-script instead of exporting them via GITHUB_ENV shell commands.
- Match and replace existing bot comments using the trusted workflow_run.name rather than a user-supplied PR title from artifacts, and streamline the logic for when comments are created.

</details>